### PR TITLE
Change how listen mode is updated and prevent drops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ spin = "0.5"
 [dev-dependencies]
 crossbeam-channel = "0.4"
 criterion = "0.2"
-async-std = "1.5"
+async-std = { version = "1.5", features = ["attributes"] }
 
 [[bench]]
 name = "basic"

--- a/src/async.rs
+++ b/src/async.rs
@@ -39,7 +39,7 @@ impl<'a, T> Future for RecvFuture<'a, T> {
                 });
                 Poll::Ready(Ok(msg))
             },
-            Err((_guard, TryRecvError::Disconnected)) => Poll::Ready(Err(RecvError::Disconnected)),
+            Err((_, TryRecvError::Disconnected)) => Poll::Ready(Err(RecvError::Disconnected)),
             Err((mut inner, TryRecvError::Empty)) => {
                 // Inform the sender that we need waking
                 inner.listen_mode = 2;

--- a/src/async.rs
+++ b/src/async.rs
@@ -34,15 +34,15 @@ impl<'a, T> Future for RecvFuture<'a, T> {
                 self.recv.shared.with_inner(|mut inner| {
                     // Detach the waker
                     inner.recv_waker = None;
-                    // Inform the sender that we need waking
-                    inner.listen_mode -= 1;
+                    // Inform the sender that we no longer need waking
+                    inner.listen_mode = 1;
                 });
                 Poll::Ready(Ok(msg))
             },
             Err((_guard, TryRecvError::Disconnected)) => Poll::Ready(Err(RecvError::Disconnected)),
             Err((mut inner, TryRecvError::Empty)) => {
-                // Inform the sender that we no longer need waking
-                inner.listen_mode += 1;
+                // Inform the sender that we need waking
+                inner.listen_mode = 2;
                 Poll::Pending
             },
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,8 +213,8 @@ impl<T> Shared<T> {
             }
 
             // Notify the receiver of a new message
-            let _ = self.wait_lock.lock().unwrap();
             drop(inner); // Avoid a deadlock
+            let _ = self.wait_lock.lock().unwrap();
             self.send_trigger.notify_one();
 
             Ok(())
@@ -302,8 +302,8 @@ impl<T> Shared<T> {
             // If there are senders waiting for a message, wake them up.
             if let Some(recv_trigger) = self.recv_trigger.as_ref() {
                 if inner.queue.is_bounded() && inner.send_waiters > 0 {
-                    let _ = self.wait_lock.lock().unwrap();
                     drop(inner);
+                    let _ = self.wait_lock.lock().unwrap();
                     recv_trigger.notify_one();
                 }
             }


### PR DESCRIPTION
- Changes listen mode from being incremented and decremented to being set to concrete values
- This solves a previous bug in master where some (<20 out of 50 million) messages would be dropped
- Added a test to make sure that in 100 million messages, no messages are dropped or reordered