### PR TITLE
Add stream impl to receiver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ readme = "README.md"
 
 [features]
 select = []
-async = []
+async = ["futures"]
 default = ["select", "async"]
 
 [dependencies]
 spin = "0.5"
+futures = { version = "^0.3", default-features = false, optional = true }
 
 [dev-dependencies]
 crossbeam-channel = "0.4"

--- a/src/async.rs
+++ b/src/async.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 use crate::*;
-use futures::Stream;
+use futures::{Stream, stream::FusedStream, future::FusedFuture};
 
 impl<T> Receiver<T> {
     #[inline]
@@ -69,6 +69,12 @@ impl<'a, T> Future for RecvFuture<'a, T> {
     }
 }
 
+impl<'a, T> FusedFuture for RecvFuture<'a, T> {
+    fn is_terminated(&self) -> bool {
+        self.recv.shared.is_disconnected()
+    }
+}
+
 impl<T> Stream for Receiver<T> {
     type Item = T;
 
@@ -78,5 +84,11 @@ impl<T> Stream for Receiver<T> {
     
     fn size_hint(&self) -> (usize, Option<usize>) {
 	    (self.buffer.borrow().len(), None)
+    }
+}
+
+impl<T> FusedStream for Receiver<T> {
+    fn is_terminated(&self) -> bool {
+        self.shared.is_disconnected()
     }
 }

--- a/src/async.rs
+++ b/src/async.rs
@@ -75,4 +75,8 @@ impl<T> Stream for Receiver<T> {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.poll(cx).map(|ready| ready.ok())
     }
+    
+    fn size_hint(&self) -> (usize, Option<usize>) {
+	    (self.buffer.borrow().len(), None)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,7 @@ impl<T> Shared<T> {
     }
 
     #[inline]
+    #[cfg(feature = "async")]
     fn poll_inner(&self) -> Option<spin::MutexGuard<'_, Inner<T>>> {
         self.inner.try_lock()
     }


### PR DESCRIPTION
This adds an implementation of `futures::Stream` to the receiver. It adds a dependency (with no default features) on `futures`. If this crate were to be incorporated into `std`, then this piece of code could probably be removed, as the future of `Stream` is still (AFAIK) uncertain. However, it's a nice convenience impl for other users of this crate.