### PR TITLE
Use loom checker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = ["select", "async"]
 [dependencies]
 spin = "0.5"
 futures = { version = "^0.3", default-features = false, optional = true }
+loom = { version = "0.3", optional = true }
 
 [dev-dependencies]
 crossbeam-channel = "0.4"

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,5 +1,6 @@
 use flume::*;
 
+#[cfg(not(feature = "loom"))]
 #[cfg(feature = "async")]
 #[test]
 fn r#async() {
@@ -17,6 +18,7 @@ fn r#async() {
     t.join().unwrap();
 }
 
+#[cfg(not(feature = "loom"))]
 #[cfg(feature = "async")]
 #[async_std::test]
 async fn send_100_million_no_drop_or_reorder() {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -59,6 +59,7 @@ fn iter_threaded() {
     });
 }
 
+#[cfg(not(feature = "loom"))]
 #[test]
 fn recv_timeout() {
     model(|| {
@@ -79,6 +80,7 @@ fn recv_timeout() {
     });
 }
 
+#[cfg(not(feature = "loom"))]
 #[test]
 fn recv_deadline() {
     model(|| {
@@ -208,7 +210,7 @@ fn rendezvous() {
     model(|| {
         let (tx, rx) = bounded(0);
 
-        for i in 0..3 {
+        for i in 0..20 {
             let tx = tx.clone();
             let t = loom::thread::spawn(move || {
                 assert!(tx.try_send(()).is_err());

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,307 +1,353 @@
 use std::time::{Instant, Duration};
 use flume::*;
 
+#[cfg(not(feature = "loom"))]
+mod loom {
+    pub use std::thread;
+    pub use std::sync;
+
+    pub fn model<F>(f: F)
+    where
+        F: Fn() + Sync + Send + 'static
+    {
+        f()
+    }
+}
+
+use loom::model;
+
+
 #[test]
 fn send_recv() {
-    let (tx, rx) = unbounded();
-    for i in 0..1000 { tx.send(i).unwrap(); }
-    for i in 0..1000 { assert_eq!(rx.try_recv().unwrap(), i); }
-    assert!(rx.try_recv().is_err());
+    model(|| {
+        let (tx, rx) = unbounded();
+        for i in 0..10 { tx.send(i).unwrap(); }
+        for i in 0..10 { assert_eq!(rx.try_recv().unwrap(), i); }
+        assert!(rx.try_recv().is_err());
+    });
 }
 
 #[test]
 fn iter() {
-    let (tx, rx) = unbounded();
-    for i in 0..1000 { tx.send(i).unwrap(); }
-    drop(tx);
-    assert_eq!(rx.iter().sum::<u32>(), (0..1000).sum());
+    model(|| {
+        let (tx, rx) = unbounded();
+        for i in 0..10 { tx.send(i).unwrap(); }
+        drop(tx);
+        assert_eq!(rx.iter().sum::<u32>(), (0..10).sum());
+    });
 }
 
 #[test]
 fn try_iter() {
-    let (tx, rx) = unbounded();
-    for i in 0..1000 { tx.send(i).unwrap(); }
-    assert_eq!(rx.try_iter().sum::<u32>(), (0..1000).sum());
+    model(|| {
+        let (tx, rx) = unbounded();
+        for i in 0..10 { tx.send(i).unwrap(); }
+        assert_eq!(rx.try_iter().sum::<u32>(), (0..10).sum());
+    });
 }
 
 #[test]
 fn iter_threaded() {
-    let (tx, rx) = unbounded();
-    for i in 0..1000 {
-        let tx = tx.clone();
-        std::thread::spawn(move || tx.send(i).unwrap());
-    }
-    drop(tx);
-    assert_eq!(rx.iter().sum::<u32>(), (0..1000).sum());
+    model(|| {
+        let (tx, rx) = unbounded();
+        for i in 0..3 {
+            let tx = tx.clone();
+            loom::thread::spawn(move || tx.send(i).unwrap());
+        }
+        drop(tx);
+        assert_eq!(rx.iter().sum::<u32>(), (0..3).sum());
+    });
 }
 
 #[test]
 fn recv_timeout() {
-    let (tx, rx) = unbounded();
+    model(|| {
+        let (tx, rx) = unbounded();
 
-    let dur = Duration::from_millis(350);
-    let then = Instant::now();
-    assert!(rx.recv_timeout(dur).is_err());
-    let now = Instant::now();
+        let dur = Duration::from_millis(350);
+        let then = Instant::now();
+        assert!(rx.recv_timeout(dur).is_err());
+        let now = Instant::now();
 
-    let max_error = Duration::from_millis(1);
-    assert!(now.duration_since(then) < dur.checked_add(max_error).unwrap());
-    assert!(now.duration_since(then) > dur.checked_sub(max_error).unwrap());
+        let max_error = Duration::from_millis(1);
+        assert!(now.duration_since(then) < dur.checked_add(max_error).unwrap());
+        assert!(now.duration_since(then) > dur.checked_sub(max_error).unwrap());
 
-    tx.send(42).unwrap();
-    assert_eq!(rx.recv_timeout(dur), Ok(42));
-    assert!(Instant::now().duration_since(now) < max_error);
+        tx.send(42).unwrap();
+        assert_eq!(rx.recv_timeout(dur), Ok(42));
+        assert!(Instant::now().duration_since(now) < max_error);
+    });
 }
 
 #[test]
 fn recv_deadline() {
-    let (tx, rx) = unbounded();
+    model(|| {
+        let (tx, rx) = unbounded();
 
-    let dur = Duration::from_millis(350);
-    let then = Instant::now();
-    assert!(rx.recv_deadline(then.checked_add(dur).unwrap()).is_err());
-    let now = Instant::now();
+        let dur = Duration::from_millis(350);
+        let then = Instant::now();
+        assert!(rx.recv_deadline(then.checked_add(dur).unwrap()).is_err());
+        let now = Instant::now();
 
-    let max_error = Duration::from_millis(10);
-    assert!(now.duration_since(then) < dur.checked_add(max_error).unwrap());
-    assert!(now.duration_since(then) > dur.checked_sub(max_error).unwrap());
+        let max_error = Duration::from_millis(10);
+        assert!(now.duration_since(then) < dur.checked_add(max_error).unwrap());
+        assert!(now.duration_since(then) > dur.checked_sub(max_error).unwrap());
 
-    tx.send(42).unwrap();
-    assert_eq!(rx.recv_deadline(now.checked_add(dur).unwrap()), Ok(42));
-    assert!(Instant::now().duration_since(now) < max_error);
+        tx.send(42).unwrap();
+        assert_eq!(rx.recv_deadline(now.checked_add(dur).unwrap()), Ok(42));
+        assert!(Instant::now().duration_since(now) < max_error);
+    });
 }
 
 #[test]
 fn disconnect_tx() {
-    let (tx, rx) = unbounded::<()>();
-    drop(tx);
-    assert!(rx.recv().is_err());
+    model(|| {
+        let (tx, rx) = unbounded::<()>();
+        drop(tx);
+        assert!(rx.recv().is_err());
+    });
 }
 
 #[test]
 fn disconnect_rx() {
-    let (tx, rx) = unbounded();
-    drop(rx);
-    assert!(tx.send(0).is_err());
+    model(|| {
+        let (tx, rx) = unbounded();
+        drop(rx);
+        assert!(tx.send(0).is_err());
+    });
 }
 
 #[test]
 fn drain() {
-    let (tx, rx) = unbounded();
+    model(|| {
+        let (tx, rx) = unbounded();
 
-    for i in 0..100 {
-        tx.send(i).unwrap();
-    }
+        for i in 0..10 {
+            tx.send(i).unwrap();
+        }
 
-    assert_eq!(rx.drain().sum::<u32>(), (0..100).sum());
+        assert_eq!(rx.drain().sum::<u32>(), (0..10).sum());
 
-    for i in 0..100 {
-        tx.send(i).unwrap();
-    }
+        for i in 0..10 {
+            tx.send(i).unwrap();
+        }
 
-    for i in 0..100 {
-        tx.send(i).unwrap();
-    }
+        for i in 0..10 {
+            tx.send(i).unwrap();
+        }
 
-    rx.recv().unwrap();
+        rx.recv().unwrap();
 
-    (1u32..100).chain(0..100).zip(rx).for_each(|(l, r)| assert_eq!(l, r));
+        (1u32..10).chain(0..10).zip(rx).for_each(|(l, r)| assert_eq!(l, r));
+    });
 }
 
 #[test]
 fn try_send() {
-    let (tx, rx) = bounded(5);
+    model(|| {
+        let (tx, rx) = bounded(5);
 
-    for i in 0..5 {
-        tx.try_send(i).unwrap();
-    }
+        for i in 0..5 {
+            tx.try_send(i).unwrap();
+        }
 
-    assert!(tx.try_send(42).is_err());
+        assert!(tx.try_send(42).is_err());
 
-    assert_eq!(rx.recv(), Ok(0));
+        assert_eq!(rx.recv(), Ok(0));
 
-    assert_eq!(tx.try_send(42), Ok(()));
+        assert_eq!(tx.try_send(42), Ok(()));
 
-    assert_eq!(rx.recv(), Ok(1));
-    drop(rx);
+        assert_eq!(rx.recv(), Ok(1));
+        drop(rx);
 
-    assert!(tx.try_send(42).is_err());
+        assert!(tx.try_send(42).is_err());
+    });
 }
 
 #[test]
 fn send_bounded() {
-    let (tx, rx) = bounded(5);
+    model(|| {
+        let (tx, rx) = bounded(5);
 
-    for _ in 0..5 {
+        for _ in 0..5 {
+            tx.send(42).unwrap();
+        }
+
+        let _ = rx.recv().unwrap();
+
         tx.send(42).unwrap();
-    }
 
-    let _ = rx.recv().unwrap();
+        assert!(tx.try_send(42).is_err());
 
-    tx.send(42).unwrap();
+        rx.drain();
 
-    assert!(tx.try_send(42).is_err());
+        let mut ts = Vec::new();
+        for _ in 0..3 {
+            let tx = tx.clone();
+            ts.push(loom::thread::spawn(move || {
+                for i in 0..10 {
+                    tx.send(i).unwrap();
+                }
+            }));
+        }
 
-    rx.drain();
+        drop(tx);
 
-    let mut ts = Vec::new();
-    for _ in 0..100 {
-        let tx = tx.clone();
-        ts.push(std::thread::spawn(move || {
-            for i in 0..10000 {
-                tx.send(i).unwrap();
-            }
-        }));
-    }
+        assert_eq!(rx.iter().sum::<u64>(), (0..10).sum::<u64>() * 3);
 
-    drop(tx);
+        for t in ts {
+            t.join().unwrap();
+        }
 
-    assert_eq!(rx.iter().sum::<u64>(), (0..10000).sum::<u64>() * 100);
-
-    for t in ts {
-        t.join().unwrap();
-    }
-
-    assert!(rx.recv().is_err());
+        assert!(rx.recv().is_err());
+    });
 }
 
 #[test]
 fn rendezvous() {
-    let (tx, rx) = bounded(0);
+    model(|| {
+        let (tx, rx) = bounded(0);
 
-    for i in 0..20 {
-        let tx = tx.clone();
-        let t = std::thread::spawn(move || {
-            assert!(tx.try_send(()).is_err());
+        for i in 0..3 {
+            let tx = tx.clone();
+            let t = loom::thread::spawn(move || {
+                assert!(tx.try_send(()).is_err());
 
-            let then = Instant::now();
-            tx.send(()).unwrap();
-            let now = Instant::now();
+                let then = Instant::now();
+                tx.send(()).unwrap();
+                let now = Instant::now();
 
-            assert!(now.duration_since(then) > Duration::from_millis(50), "iter = {}", i);
-        });
+                assert!(now.duration_since(then) > Duration::from_millis(50), "iter = {}", i);
+            });
 
-        std::thread::sleep(Duration::from_millis(250));
-        rx.recv().unwrap();
+            std::thread::sleep(Duration::from_millis(250));
+            rx.recv().unwrap();
 
-        t.join().unwrap();
-    }
+            t.join().unwrap();
+        }
+    });
 }
 
 #[test]
 fn hydra() {
-    let thread_num = 32;
-    let msg_num = 1000;
+    model(|| {
+        let thread_num = 3;
+        let msg_num = 10;
 
-    let (main_tx, main_rx) = unbounded::<()>();
+        let (main_tx, main_rx) = unbounded::<()>();
 
-    let mut txs = Vec::new();
-    for _ in 0..thread_num {
-        let main_tx = main_tx.clone();
-        let (tx, rx) = unbounded();
-        txs.push(tx);
-
-        std::thread::spawn(move || {
-            for msg in rx.iter() {
-                main_tx.send(msg).unwrap();
-            }
-        });
-    }
-
-    drop(main_tx);
-
-    for _ in 0..10000 {
-        for tx in &txs {
-            for _ in 0..msg_num {
-                tx.send(Default::default()).unwrap();
-            }
-        }
-
+        let mut txs = Vec::new();
         for _ in 0..thread_num {
-            for _ in 0..msg_num {
-                main_rx.recv().unwrap();
+            let main_tx = main_tx.clone();
+            let (tx, rx) = unbounded();
+            txs.push(tx);
+
+            loom::thread::spawn(move || {
+                for msg in rx.iter() {
+                    main_tx.send(msg).unwrap();
+                }
+            });
+        }
+
+        drop(main_tx);
+
+        for _ in 0..3 {
+            for tx in &txs {
+                for _ in 0..msg_num {
+                    tx.send(Default::default()).unwrap();
+                }
+            }
+
+            for _ in 0..thread_num {
+                for _ in 0..msg_num {
+                    main_rx.recv().unwrap();
+                }
             }
         }
-    }
 
-    drop(txs);
-    assert!(main_rx.recv().is_err());
+        drop(txs);
+        assert!(main_rx.recv().is_err());
+    });
 }
 
 #[test]
 fn robin() {
-    let thread_num = 32;
-    let msg_num = 10;
+    model(|| {
+        let thread_num = 2;
+        let msg_num = 10;
 
-    let (mut main_tx, main_rx) = bounded::<()>(1);
+        let (mut main_tx, main_rx) = bounded::<()>(1);
 
-    for _ in 0..thread_num {
-        let (mut tx, rx) = bounded(100);
-        std::mem::swap(&mut tx, &mut main_tx);
+        for _ in 0..thread_num {
+            let (mut tx, rx) = bounded(100);
+            std::mem::swap(&mut tx, &mut main_tx);
 
-        std::thread::spawn(move || {
-            for msg in rx.iter() {
-                tx.send(msg).unwrap();
-            }
-        });
-    }
-
-    for _ in 0..10000 {
-        let main_tx = main_tx.clone();
-        std::thread::spawn(move || {
-            for _ in 0..msg_num {
-                main_tx.send(Default::default()).unwrap();
-            }
-        });
-
-        for _ in 0..msg_num {
-            main_rx.recv().unwrap();
+            loom::thread::spawn(move || {
+                for msg in rx.iter() {
+                    tx.send(msg).unwrap();
+                }
+            });
         }
-    }
+
+        for _ in 0..1 {
+            let main_tx = main_tx.clone();
+            loom::thread::spawn(move || {
+                for _ in 0..msg_num {
+                    main_tx.send(Default::default()).unwrap();
+                }
+            });
+
+            for _ in 0..msg_num {
+                main_rx.recv().unwrap();
+            }
+        }
+    });
 }
 
 #[cfg(feature = "select")]
 #[test]
 fn select() {
-    #[derive(Debug, PartialEq)]
-    struct Foo(usize);
+    model(|| {
+        #[derive(Debug, PartialEq)]
+        struct Foo(usize);
 
-    let (tx0, rx0) = bounded(1);
-    let (tx1, rx1) = unbounded();
+        let (tx0, rx0) = bounded(1);
+        let (tx1, rx1) = unbounded();
 
-    for (i, t) in vec![tx0.clone(), tx1].into_iter().enumerate() {
-        std::thread::spawn(move || {
+        for (i, t) in vec![tx0.clone(), tx1].into_iter().enumerate() {
+            loom::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let _ = t.send(Foo(i));
+            });
+        }
+
+
+        let x = Selector::new()
+            .recv(&rx0, |x| x)
+            .recv(&rx1, |x| x)
+            .wait()
+            .unwrap();
+
+        if x == Foo(0) {
+            assert!(rx1.recv().unwrap() == Foo(1));
+        } else {
+            assert!(rx0.recv().unwrap() == Foo(0));
+        }
+
+        tx0.send(Foo(42)).unwrap();
+
+        let t = loom::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(100));
-            let _ = t.send(Foo(i));
+            assert_eq!(rx0.recv().unwrap(), Foo(42));
+            assert_eq!(rx0.recv().unwrap(), Foo(43));
+
         });
-    }
 
+        Selector::new()
+            .send(&tx0, Foo(43), |x| x)
+            .wait()
+            .unwrap();
 
-    let x = Selector::new()
-        .recv(&rx0, |x| x)
-        .recv(&rx1, |x| x)
-        .wait()
-        .unwrap();
-
-    if x == Foo(0) {
-        assert!(rx1.recv().unwrap() == Foo(1));
-    } else {
-        assert!(rx0.recv().unwrap() == Foo(0));
-    }
-
-    tx0.send(Foo(42)).unwrap();
-
-    let t = std::thread::spawn(move || {
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        assert_eq!(rx0.recv().unwrap(), Foo(42));
-        assert_eq!(rx0.recv().unwrap(), Foo(43));
-
+        t.join().unwrap();
     });
-
-    Selector::new()
-        .send(&tx0, Foo(43), |x| x)
-        .wait()
-        .unwrap();
-
-    t.join().unwrap();
 }


### PR DESCRIPTION
This PR introduced loom to help concurrent testing.

It took too long time in some tests because of too many branches. and, because loom does not support `wait_timeout`, the test using it will cause a deadlock false positive.