### PR TITLE
Implement into_{sink,stream} and make async methods return concrete types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ crossbeam-channel = "0.4"
 crossbeam-utils = "0.7"
 criterion = "0.3.1"
 rand = "0.7"
-async-std = { version = "1.5", features = ["attributes"] }
+async-std = { version = "1.5", features = ["attributes", "unstable"] }
+futures = { version = "^0.3", features = ["std"] }
 
 [[bench]]
 name = "basic"

--- a/src/async.rs
+++ b/src/async.rs
@@ -261,6 +261,8 @@ impl<'a, T> RecvFut<'a, T> {
             } else if self.receiver.shared.is_disconnected() {
                 Poll::Ready(Err(RecvError::Disconnected))
             } else {
+                let hook = self.hook.as_ref().map(Arc::clone).unwrap();
+                wait_lock(&self.receiver.shared.chan).waiting.push_back(hook);
                 Poll::Pending
             }
         } else {

--- a/src/async.rs
+++ b/src/async.rs
@@ -177,6 +177,15 @@ impl<'a, T: Unpin> Sink<T> for SendSink<'a, T> {
     }
 }
 
+impl<'a, T: Unpin> Clone for SendSink<'a, T> {
+    fn clone(&self) -> SendSink<'a, T> {
+        SendSink(SendFuture {
+            sender: self.0.sender.clone(),
+            hook: None
+        })
+    }
+}
+
 impl<T> Receiver<T> {
     /// Asynchronously wait for an incoming value from the channel associated with this receiver,
     /// returning an error if all channel senders have been dropped.
@@ -275,6 +284,12 @@ impl<'a, T> FusedFuture for RecvFut<'a, T> {
 
 /// A stream which allows asynchronously receiving messages.
 pub struct RecvStream<'a, T>(RecvFut<'a, T>);
+
+impl<'a, T> Clone for RecvStream<'a, T> {
+    fn clone(&self) -> RecvStream<'a, T> {
+        RecvStream(RecvFut::new(self.0.receiver.clone()))
+    }
+}
 
 impl<'a, T> Stream for RecvStream<'a, T> {
     type Item = T;

--- a/src/async.rs
+++ b/src/async.rs
@@ -147,6 +147,12 @@ impl<'a, T: Unpin> FusedFuture for SendFuture<'a, T> {
 /// A sink that allows sending values into a channel.
 pub struct SendSink<'a, T: Unpin>(SendFuture<'a, T>);
 
+impl<'a, T: Unpin> SendSink<'a, T> {
+    pub fn is_disconnected(&self) -> bool {
+        self.0.is_terminated()
+    }
+}
+
 impl<'a, T: Unpin> Sink<T> for SendSink<'a, T> {
     type Error = SendError<T>;
 

--- a/src/async.rs
+++ b/src/async.rs
@@ -304,7 +304,7 @@ impl<'a, T> Future for RecvFut<'a, T> {
 
 impl<'a, T> FusedFuture for RecvFut<'a, T> {
     fn is_terminated(&self) -> bool {
-        self.receiver.shared.is_disconnected()
+        self.receiver.shared.is_disconnected() && self.receiver.shared.is_empty()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,8 +346,6 @@ impl<T> Shared<T> {
         if self.is_disconnected() {
             Err(TrySendTimeoutError::Disconnected(msg)).into()
         } else if !chan.waiting.is_empty() {
-            debug_assert!(chan.queue.is_empty());
-
             let mut msg = Some(msg);
 
             // TODO(stream): investigate how this impacts starvation
@@ -362,7 +360,7 @@ impl<T> Shared<T> {
                     },
                     Some((Some(m), false)) => {
                         // Was async and not a stream, so it did acquire the message. Push the
-                        // message to the queue.
+                        // message to the queue for it to be received.
                         chan.queue.push_front(m);
                         break
                     }

--- a/src/select.rs
+++ b/src/select.rs
@@ -12,10 +12,11 @@ type Token = usize;
 struct SelectSignal(thread::Thread, Token, AtomicBool, Arc<Spinlock<VecDeque<Token>>>);
 
 impl Signal for SelectSignal {
-    fn fire(&self) {
+    fn fire(&self) -> bool {
         self.2.store(true, Ordering::SeqCst);
         self.3.lock().push_back(self.1);
         self.0.unpark();
+        true
     }
 
     fn as_any(&self) -> &(dyn Any + 'static) { self }

--- a/src/select.rs
+++ b/src/select.rs
@@ -19,6 +19,7 @@ impl Signal for SelectSignal {
     }
 
     fn as_any(&self) -> &(dyn Any + 'static) { self }
+    fn as_ptr(&self) -> *const () { self as *const _ as *const () }
 }
 
 trait Selection<'a, T> {
@@ -157,7 +158,7 @@ impl<'a, T> Selector<'a, T> {
                     wait_lock(&self.sender.shared.chan).sending
                         .as_mut()
                         .unwrap().1
-                        .retain(|s| s.signal().as_any() as *const _ != hook.signal().as_any() as *const _);
+                        .retain(|s| s.signal().as_ptr() != hook.signal().as_ptr());
                 }
             }
         }

--- a/src/select.rs
+++ b/src/select.rs
@@ -16,7 +16,7 @@ impl Signal for SelectSignal {
         self.2.store(true, Ordering::SeqCst);
         self.3.lock().push_back(self.1);
         self.0.unpark();
-        true
+        false
     }
 
     fn as_any(&self) -> &(dyn Any + 'static) { self }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -3,6 +3,7 @@ use std::{thread::{self, Thread}, time::Duration, any::Any};
 pub trait Signal: Send + Sync + 'static {
     fn fire(&self);
     fn as_any(&self) -> &(dyn Any + 'static);
+    fn as_ptr(&self) -> *const ();
 }
 
 pub struct SyncSignal(Thread);
@@ -14,8 +15,9 @@ impl Default for SyncSignal {
 }
 
 impl Signal for SyncSignal {
-    fn as_any(&self) -> &(dyn Any + 'static) { self }
     fn fire(&self) { self.0.unpark(); }
+    fn as_any(&self) -> &(dyn Any + 'static) { self }
+    fn as_ptr(&self) -> *const () { self as *const _ as *const () }
 }
 
 impl SyncSignal {

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,8 +1,10 @@
 use std::{thread::{self, Thread}, time::Duration, any::Any};
 
 pub trait Signal: Send + Sync + 'static {
-    /// Fire the signal, returning whether it is a stream signal
-    // TODO(stream) explain why this matters
+    /// Fire the signal, returning whether it is a stream signal. This is because streams do not
+    /// acquire a message when woken, so signals must be fired until one that does acquire a message
+    /// is fired, otherwise a wakeup could be missed, leading to a lost message until one is eagerly
+    /// grabbed by a receiver.
     fn fire(&self) -> bool;
     fn as_any(&self) -> &(dyn Any + 'static);
     fn as_ptr(&self) -> *const ();

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,7 +1,9 @@
 use std::{thread::{self, Thread}, time::Duration, any::Any};
 
 pub trait Signal: Send + Sync + 'static {
-    fn fire(&self);
+    /// Fire the signal, returning whether it is a stream signal
+    // TODO(stream) explain why this matters
+    fn fire(&self) -> bool;
     fn as_any(&self) -> &(dyn Any + 'static);
     fn as_ptr(&self) -> *const ();
 }
@@ -15,7 +17,10 @@ impl Default for SyncSignal {
 }
 
 impl Signal for SyncSignal {
-    fn fire(&self) { self.0.unpark(); }
+    fn fire(&self) -> bool {
+        self.0.unpark();
+        true
+    }
     fn as_any(&self) -> &(dyn Any + 'static) { self }
     fn as_ptr(&self) -> *const () { self as *const _ as *const () }
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -19,7 +19,7 @@ impl Default for SyncSignal {
 impl Signal for SyncSignal {
     fn fire(&self) -> bool {
         self.0.unpark();
-        true
+        false
     }
     fn as_any(&self) -> &(dyn Any + 'static) { self }
     fn as_ptr(&self) -> *const () { self as *const _ as *const () }


### PR DESCRIPTION
To do:
- [x] Fix stream impls (pre-existing issue in flume)
- [x] Stream tests
- [x] Figure out how the stream changes work with `eventual-fairness`