### PR TITLE
Break up futures crate into futures_core and futures_sink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,14 @@ exclude = ["misc"]
 
 [features]
 select = []
-async = ["futures"]
+async = ["futures-sink", "futures-core"]
 eventual-fairness = ["async", "rand"]
 default = ["async", "select", "eventual-fairness"]
 
 [dependencies]
 spinning_top = "0.2"
-futures = { version = "^0.3", default-features = false, optional = true }
+futures-sink = { version = "0.3.5", default_features = false, optional = true }
+futures-core = { version = "0.3.5", default_features = false, optional = true }
 rand = { version = "0.7", optional = true }
 
 [dev-dependencies]

--- a/src/async.rs
+++ b/src/async.rs
@@ -8,7 +8,8 @@ use std::{
     ops::Deref,
 };
 use crate::*;
-use futures::{Stream, stream::FusedStream, future::FusedFuture, Sink};
+use futures_core::{stream::{Stream, FusedStream}, future::FusedFuture};
+use futures_sink::Sink;
 
 struct AsyncSignal {
     waker: Waker,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -230,7 +230,7 @@ fn rendezvous() {
             assert!(now.duration_since(then) > Duration::from_millis(50), "iter = {}", i);
         });
 
-        std::thread::sleep(Duration::from_millis(250));
+        std::thread::sleep(Duration::from_millis(500));
         rx.recv().unwrap();
 
         t.join().unwrap();


### PR DESCRIPTION
This removes unnecessary dependencies on futures_channel, futures_util, etc.