### PR TITLE
Remove unneeded Debug constraint from std::error::Error impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl<T> fmt::Display for SendError<T> {
     }
 }
 
-impl<T> std::error::Error for SendError<T> where T: fmt::Debug {}
+impl<T> std::error::Error for SendError<T> {}
 
 /// An error that may be emitted when attempting to send a value into a channel on a sender.
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -79,7 +79,7 @@ impl<T> fmt::Display for TrySendError<T> {
     }
 }
 
-impl<T> std::error::Error for TrySendError<T> where T: fmt::Debug {}
+impl<T> std::error::Error for TrySendError<T> {}
 
 /// An error that may be emitted when sending a value into a channel on a sender with a timeout.
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -103,7 +103,7 @@ impl<T> fmt::Display for SendTimeoutError<T> {
     }
 }
 
-impl<T> std::error::Error for SendTimeoutError<T> where T: fmt::Debug {}
+impl<T> std::error::Error for SendTimeoutError<T> {}
 
 enum TrySendTimeoutError<T> {
     Full(T),

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -354,3 +354,55 @@ fn select_general() {
 
     t.join().unwrap();
 }
+
+struct MessageWithoutDebug(u32);
+
+#[test]
+// This is a 'does it build' test, to make sure that the error types can turn
+// into a std::error::Error without requiring the payload (which is not used
+// there) to impl Debug.
+fn std_error_without_debug() {
+    let (tx, rx) = unbounded::<MessageWithoutDebug>();
+
+    match tx.send(MessageWithoutDebug(1)) {
+        Ok(_) => {}
+        Err(e) => {
+            let _std_err: &dyn std::error::Error = &e;
+        }
+    }
+
+    match rx.recv() {
+        Ok(_) => {}
+        Err(e) => {
+            let _std_err: &dyn std::error::Error = &e;
+        }
+    }
+
+    match tx.try_send(MessageWithoutDebug(2)) {
+        Ok(_) => {}
+        Err(e) => {
+            let _std_err: &dyn std::error::Error = &e;
+        }
+    }
+
+    match rx.try_recv() {
+        Ok(_) => {}
+        Err(e) => {
+            let _std_err: &dyn std::error::Error = &e;
+        }
+    }
+
+    match tx.send_timeout(MessageWithoutDebug(3), Duration::from_secs(1000000)) {
+        Ok(_) => {}
+        Err(e) => {
+            let _std_err: &dyn std::error::Error = &e;
+        }
+    }
+
+    match rx.recv_timeout(Duration::from_secs(10000000)) {
+        Ok(_) => {}
+        Err(e) => {
+            let _std_err: &dyn std::error::Error = &e;
+        }
+    }
+}


### PR DESCRIPTION
This constraint prevented using any errors from a channel with non-Debug messages as `std::error::Error`. The constraint doesn't actually do anything anyway, since `std::error::Error` is implemented in terms of `Display`, not `Debug`.