### PR TITLE
Fix bug where new wakers would not be tracked

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ criterion = "0.3.1"
 rand = "0.7"
 async-std = { version = "1.5", features = ["attributes", "unstable"] }
 futures = { version = "^0.3", features = ["std"] }
+waker-fn = "1.1.0"
 
 [[bench]]
 name = "basic"


### PR DESCRIPTION
Incidentally, closes #33. This additionally changes the use of `Result<bla, T>` in `SendFut` to its own type, since it is less semantically confusing.