### PR TITLE
Switch from spinning_top to spin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ eventual-fairness = ["async", "nanorand"]
 default = ["async", "select", "eventual-fairness"]
 
 [dependencies]
-spin = "0.6.0"
+spin = { version = "0.6.0", default-features = false }
 futures-sink = { version = "0.3.5", default_features = false, optional = true }
 futures-core = { version = "0.3.5", default_features = false, optional = true }
 nanorand = { version = "0.4", features = ["getrandom"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ eventual-fairness = ["async", "nanorand"]
 default = ["async", "select", "eventual-fairness"]
 
 [dependencies]
-spinning_top = "0.2"
+spin = "0.6.0"
 futures-sink = { version = "0.3.5", default_features = false, optional = true }
 futures-core = { version = "0.3.5", default_features = false, optional = true }
 nanorand = { version = "0.4", features = ["getrandom"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use std::{
     fmt,
 };
 
-use spinning_top::{Spinlock, SpinlockGuard};
+use spin::{Mutex as Spinlock, MutexGuard as SpinlockGuard};
 use crate::signal::{Signal, SyncSignal};
 
 /// An error that may be emitted when attempting to send a value into a channel on a sender.


### PR DESCRIPTION
Since [spin is now maintained](https://github.com/RustSec/advisory-db/pull/424), it is no longer a not-so-great idea to depend on it. This reduces the number of transitive dependencies.

Dependency tree change:
```diff
  flume v0.9.1 (/home/restioson/IdeaProjects/flume)
  ├── futures-core v0.3.5
  ├── futures-sink v0.3.5
  ├── nanorand v0.4.4
  │   └── getrandom v0.2.0
  │       ├── cfg-if v0.1.10
  │       └── libc v0.2.74
- └── spinning_top v0.2.2
-   └── lock_api v0.4.1
-       └── scopeguard v1.1.0
+ └── spin v0.6.0
```

The net effect is thus that we have lost two transitive dependencies.

To do:
- Change some spinlocks to RwLocks where applicable.