### PR TITLE
Fix issue #55

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -158,7 +158,7 @@ impl<'a, T: Unpin> Future for SendFuture<'a, T> {
                 hook.update_waker(cx.waker());
                 Poll::Pending
             }
-        } else {
+        } else if let Some(SendState::NotYetSent(_)) = self.hook {
             let mut_self = self.get_mut();
             let (shared, this_hook) = (&mut_self.sender.shared, &mut mut_self.hook);
 
@@ -182,6 +182,8 @@ impl<'a, T: Unpin> Future for SendFuture<'a, T> {
                     TrySendTimeoutError::Disconnected(msg) => SendError(msg),
                     _ => unreachable!(),
                 }))
+        } else { // Nothing to do
+            Poll::Ready(Ok(()))
         }
     }
 }


### PR DESCRIPTION
We need to just return `Poll::Ready` when there is no work to do in a send future. Closes issue #55.