### PR TITLE
Fix nondeterministic bug in RecvSelection::deinit

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -282,7 +282,7 @@ impl<'a, T> Selector<'a, T> {
                     let hook: Arc<Hook<U, dyn Signal>> = hook;
                     wait_lock(&self.receiver.shared.chan)
                         .waiting
-                        .retain(|s| !Arc::ptr_eq(s, &hook));
+                        .retain(|s| s.signal().as_ptr() != hook.signal().as_ptr());
                     // If we were woken, but never polled, wake up another
                     if !self.received
                         && hook


### PR DESCRIPTION
Using Arc::ptr_eq on trait object pointers can fail unpredictably because of https://github.com/rust-lang/rust/issues/46139.

This can prevent a Hook from being removed when its RecvSelection is de-inited, which makes it incorrectly push Tokens to a queue owned by a Selector that no longer exists.

I found this bug using a test case provided by @scaphe in the Rust Users forum here: https://users.rust-lang.org/t/flume-question-possible-bug/55259

This may also be the cause of #44.