### PR TITLE
Bump outdated dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ pin-project = { version = "1", optional = true }
 
 [dev-dependencies]
 #flume-test = { path = "../flume-test" }
-crossbeam-channel = "0.4"
-crossbeam-utils = "0.7"
+crossbeam-channel = "0.5.0"
+crossbeam-utils = "0.8.1"
 criterion = "0.3.1"
-rand = "0.7"
+rand = "0.8.3"
 async-std = { version = "1.5", features = ["attributes", "unstable"] }
 futures = { version = "^0.3", features = ["std"] }
 waker-fn = "1.1.0"

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -500,8 +500,8 @@ fn drops() {
     let mut rng = thread_rng();
 
     for _ in 0..RUNS {
-        let steps = rng.gen_range(0, 10_000);
-        let additional = rng.gen_range(0, 50);
+        let steps = rng.gen_range(0..10_000);
+        let additional = rng.gen_range(0..50);
 
         DROPS.store(0, Ordering::SeqCst);
         let (s, r) = bounded::<DropCounter>(50);

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -390,8 +390,8 @@ fn drops() {
     let mut rng = thread_rng();
 
     for _ in 0..100 {
-        let steps = rng.gen_range(0, 10_000);
-        let additional = rng.gen_range(0, 1000);
+        let steps = rng.gen_range(0..10_000);
+        let additional = rng.gen_range(0..1000);
 
         DROPS.store(0, Ordering::SeqCst);
         let (s, r) = unbounded::<DropCounter>();

--- a/tests/zero.rs
+++ b/tests/zero.rs
@@ -402,7 +402,7 @@ fn drops() {
     let mut rng = thread_rng();
 
     for _ in 0..100 {
-        let steps = rng.gen_range(0, 3_000);
+        let steps = rng.gen_range(0..3_000);
 
         DROPS.store(0, Ordering::SeqCst);
         let (s, r) = bounded::<DropCounter>(0);


### PR DESCRIPTION
The code changes is that `Rng::gen_range` now uses range syntax `a..b`.