### PR TITLE
Fix compilation when `select` is only enabled feature

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -1,8 +1,10 @@
 //! Types that permit waiting upon multiple blocking operations using the [`Selector`] interface.
 
 use crate::*;
-use nanorand::RNG;
 use std::{any::Any, marker::PhantomData};
+
+#[cfg(feature = "eventual-fairness")]
+use nanorand::RNG;
 
 // A unique token corresponding to an event in a selector
 type Token = usize;


### PR DESCRIPTION
Before:

```toml
# Cargo.toml

[dependencies.flume]
default_features = false
features = ["select"]
version = "0.10.2"
```

```console
$ cargo check
    Updating crates.io index
  Downloaded spinning_top v0.2.3
  Downloaded 1 crate (48.2 KB) in 1.84s
    Checking spinning_top v0.2.3
    Checking flume v0.10.2
error[E0432]: unresolved import `nanorand`
 --> /Users/aramis/.cargo/registry/src/github.com-1ecc6299db9ec823/flume-0.10.2/src/select.rs:4:5
  |
4 | use nanorand::RNG;
  |     ^^^^^^^^ use of undeclared crate or module `nanorand`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `flume`
```

This demo compiles without issue with this PR.