### PR TITLE
Fix `cargo clippy` warnings

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -175,6 +175,7 @@ impl<'a, T> SendFut<'a, T> {
     }
 }
 
+#[allow(clippy::needless_lifetimes)] // False positive, see https://github.com/rust-lang/rust-clippy/issues/5787
 #[pinned_drop]
 impl<'a, T> PinnedDrop for SendFut<'a, T> {
     fn drop(mut self: Pin<&mut Self>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,7 +521,7 @@ impl<T> Shared<T> {
         let mut chan = wait_lock(&self.chan);
         chan.pull_pending(true);
 
-        let res = if let Some(msg) = chan.queue.pop_front() {
+        if let Some(msg) = chan.queue.pop_front() {
             drop(chan);
             Ok(msg).into()
         } else if self.is_disconnected() {
@@ -536,9 +536,7 @@ impl<T> Shared<T> {
         } else {
             drop(chan);
             Err(TryRecvTimeoutError::Empty).into()
-        };
-
-        res
+        }
     }
 
     fn recv_sync(&self, block: Option<Option<Instant>>) -> Result<T, TryRecvTimeoutError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,9 +583,9 @@ impl<T> Shared<T> {
 
         let mut chan = wait_lock(&self.chan);
         chan.pull_pending(false);
-        chan.sending.as_ref().map(|(_, sending)| sending.iter().for_each(|hook| {
+        if let Some((_, sending)) = chan.sending.as_ref() { sending.iter().for_each(|hook| {
             hook.signal().fire();
-        }));
+        }) }
         chan.waiting.iter().for_each(|hook| { hook.signal().fire(); });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ impl<T> Hook<T, SyncSignal> {
 
 #[inline]
 #[cfg(not(windows))]
-fn wait_lock<'a, T>(lock: &'a Spinlock<T>) -> SpinlockGuard<'a, T> {
+fn wait_lock<T>(lock: &Spinlock<T>) -> SpinlockGuard<T> {
     let mut i = 4;
     loop {
         for _ in 0..10 {


### PR DESCRIPTION
This resolves the warnings provided by the `cargo clippy` command, improving the readability of the code in some parts.