### PR TITLE
Update Nanorand to 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `nanorand` to `0.6`
+
 ### Fixed
 
 # [0.10.6] - 2021-06-10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default = ["async", "select", "eventual-fairness"]
 spinning_top = "0.2"
 futures-sink = { version = "0.3", default_features = false, optional = true }
 futures-core = { version = "0.3", default_features = false, optional = true }
-nanorand = { version = "0.5", features = ["getrandom"], optional = true }
+nanorand = { version = "0.6", features = ["getrandom"], optional = true }
 pin-project = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/src/select.rs
+++ b/src/select.rs
@@ -4,7 +4,7 @@ use crate::*;
 use std::{any::Any, marker::PhantomData};
 
 #[cfg(feature = "eventual-fairness")]
-use nanorand::RNG;
+use nanorand::Rng;
 
 // A unique token corresponding to an event in a selector
 type Token = usize;
@@ -319,7 +319,7 @@ impl<'a, T> Selector<'a, T> {
     fn wait_inner(mut self, deadline: Option<Instant>) -> Option<T> {
         #[cfg(feature = "eventual-fairness")]
         {
-            self.next_poll = self.rng.generate_range(0, self.selections.len());
+            self.next_poll = self.rng.generate_range(0..self.selections.len());
         }
 
         let res = 'outer: loop {


### PR DESCRIPTION
This helps eliminate nanorand as a duplicate dep in upstream projects.