### PR TITLE
Fix out-of-order receive in async single-producer single-consumer scenario (# 98)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ rand = "0.8.3"
 async-std = { version = "1.9.0", features = ["attributes", "unstable"] }
 futures = { version = "^0.3", features = ["std"] }
 waker-fn = "1.1.0"
+tokio = { version = "^1.16.1", features = ["rt", "macros"] }
 
 [[bench]]
 name = "basic"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,7 +465,7 @@ impl<T> Shared<T> {
                     None if msg.is_none() => break,
                     // No more waiting receivers, so add msg to queue and break out of the loop
                     None => {
-                        chan.queue.push_front(msg.unwrap());
+                        chan.queue.push_back(msg.unwrap());
                         break;
                     }
                     Some((Some(m), signal)) => {
@@ -477,7 +477,7 @@ impl<T> Shared<T> {
                         } else {
                             // Was async and not a stream, so it did acquire the message. Push the
                             // message to the queue for it to be received.
-                            chan.queue.push_front(m);
+                            chan.queue.push_back(m);
                             drop(chan);
                             break;
                         }


### PR DESCRIPTION
Fixing #98:
 - Add a dedicated test case (fails before the fix, passes afterwards).
 - Fix certain paths in `Shared::<T>::send()` to perform `push_back` instead of `push_front`.