### PR TITLE
Upgrade nanorand to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default = ["async", "select", "eventual-fairness"]
 spin1 = { package = "spin", version = "0.9.2", features = ["mutex"] }
 futures-sink = { version = "0.3", default_features = false, optional = true }
 futures-core = { version = "0.3", default_features = false, optional = true }
-nanorand = { version = "0.6", features = ["getrandom"], optional = true }
+nanorand = { version = "0.7", features = ["getrandom"], optional = true }
 pin-project = { version = "1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Just a dependency bump. Should be semver compatible