### PR TITLE
Add a method to get the underlying Sender from a SendSink

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -252,8 +252,8 @@ pub struct SendSink<'a, T>(SendFut<'a, T>);
 
 impl<'a, T> SendSink<'a, T> {
     /// Returns a clone of a sending half of the channel of this sink.
-    pub fn sender(&self) -> Sender<T> {
-        (*self.0.sender).clone()
+    pub fn sender(&self) -> &Sender<T> {
+        &self.0.sender
     }
 
     /// See [`Sender::is_disconnected`].

--- a/src/async.rs
+++ b/src/async.rs
@@ -251,6 +251,11 @@ impl<'a, T> FusedFuture for SendFut<'a, T> {
 pub struct SendSink<'a, T>(SendFut<'a, T>);
 
 impl<'a, T> SendSink<'a, T> {
+    /// Returns a clone of a sending half of the channel of this sink.
+    pub fn sender(&self) -> Sender<T> {
+        (*self.0.sender).clone()
+    }
+
     /// See [`Sender::is_disconnected`].
     pub fn is_disconnected(&self) -> bool {
         self.0.is_disconnected()


### PR DESCRIPTION
This allows for a bit more flexibility in how channels are stored. My personal use case for this is, in xtra, allowing Addresses to implement Sink directly by keeping only a copy of the SendSink, and converting back to Senders to get owning send futures when that is required. Otherwise, both a Sender and SendSink for the same channel would need to be stored.

Technically, this could be implemented on SendFut too, but I am less sure of the general API coherence and usefulness of this. It makes more sense on SendSink, since SendSink is logically an entry point into a channel, whereas SendFuture is more of a handle to some transaction in progress. Thus, it makes more sense to change between types of channel entrypoints (senders and sinks), but a little less to change between a sending transaction and the entrypoint. Let me know what you think about this, though.