### PR TITLE
Create a `WeakSender` type that does not keep the channel open

### DIFF
--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -405,3 +405,24 @@ fn std_error_without_debug() {
         }
     }
 }
+
+#[test]
+fn weak_close() {
+    let (tx, rx) = unbounded::<()>();
+    let weak = tx.downgrade();
+    drop(tx);
+    assert!(weak.upgrade().is_none());
+    assert!(rx.is_disconnected());
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn weak_upgrade() {
+    let (tx, rx) = unbounded();
+    let weak = tx.downgrade();
+    let tx2 = weak.upgrade().unwrap();
+    drop(tx);
+    assert!(!rx.is_disconnected());
+    tx2.send(()).unwrap();
+    assert!(rx.try_recv().is_ok());
+}


### PR DESCRIPTION
Creates a `WeakSender` type, which can be constructed through a new `Sender::downgrade` method. Similar to the [`sync::Weak`](https://doc.rust-lang.org/stable/std/sync/struct.Weak.html) of the standard library, the `WeakSender` does not count towards ownership. That means that the channel is closed as soon as all `Sender`s are closed, even if there are still active `WeakSender`s.

Resolves #107 