### PR TITLE
Clean up some of the async code + remove pin_project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 # Use a spinlock internally (may be faster on some platforms)
 spin = []
 select = []
-async = ["futures-sink", "futures-core", "pin-project"]
+async = ["futures-sink", "futures-core"]
 eventual-fairness = ["async", "nanorand"]
 default = ["async", "select", "eventual-fairness"]
 
@@ -27,7 +27,6 @@ spin1 = { package = "spin", version = "0.9.2", features = ["mutex"] }
 futures-sink = { version = "0.3", default_features = false, optional = true }
 futures-core = { version = "0.3", default_features = false, optional = true }
 nanorand = { version = "0.7", features = ["getrandom"], optional = true }
-pin-project = { version = "1", optional = true }
 
 [dev-dependencies]
 #flume-test = { path = "../flume-test" }


### PR DESCRIPTION
I was adding a `SendFut::into_item()` function until I realized that I could do what I was trying to by just. re-polling the future later. but I didn't want to throw away the little clean ups I had made, so here they are. Gets rid of an unnecessary dependency!
