### PR TITLE
Add `SendFut::into_inner`.

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -155,6 +155,14 @@ impl<'a, T> SendFut<'a, T> {
         }
     }
 
+    /// Consume `self` returning the queued value if it has not yet been sent.
+    pub fn into_inner(mut self) -> Option<T> {
+        self.hook.take().and_then(|state| match state {
+            SendState::NotYetSent(value) => Some(value),
+            SendState::QueuedItem(hook) => hook.try_take(),
+        })
+    }
+
     /// See [`Sender::is_disconnected`].
     pub fn is_disconnected(&self) -> bool {
         self.sender.is_disconnected()


### PR DESCRIPTION
This is the first step for adding a `send_timeout_async` and `send_deadling_async`.
This provides the ability to consume a `SendFut` returning its contained value if the value has not yet been sent.