### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ eventual-fairness = ["async", "nanorand"]
 default = ["async", "select", "eventual-fairness"]
 
 [dependencies]
-spin1 = { package = "spin", version = "0.9.2", features = ["mutex"] }
+spin1 = { package = "spin", version = "0.9.8", features = ["mutex"] }
 futures-sink = { version = "0.3", default_features = false, optional = true }
 futures-core = { version = "0.3", default_features = false, optional = true }
 nanorand = { version = "0.7", features = ["getrandom"], optional = true }


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)