### PR TITLE
Make remaining core channel spinlock opt-in

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -10,6 +10,7 @@ use std::{
 use crate::*;
 use futures_core::{stream::{Stream, FusedStream}, future::FusedFuture};
 use futures_sink::Sink;
+use spin1::Mutex as Spinlock;
 
 struct AsyncSignal {
     waker: Spinlock<Waker>,

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,6 +1,7 @@
 //! Types that permit waiting upon multiple blocking operations using the [`Selector`] interface.
 
 use crate::*;
+use spin1::Mutex as Spinlock;
 use std::{any::Any, marker::PhantomData};
 
 #[cfg(feature = "eventual-fairness")]


### PR DESCRIPTION
This makes the remaining use of spinlocks in the core flume channel implementation opt-in based on the `spin` feature.  Without this change the crate cannot safely be used in RTOS systems due to priority inversion issues leading to the spinlock spinning forever and lower-priority threads never getting a chance to run.

I've left the async and select modules alone for now since we do not have a use for these at the moment, but I think it would make sense to perform the same change there as well.  If you wish I could look into doing it as part of the same PR.