### PR TITLE
Add `Clone` conformance to `WeakSender`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `WeakSender` is now `Clone`
+
 ### Fixed
 
 # [0.11.0] - 2023-08-16

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -858,6 +858,13 @@ impl<T> WeakSender<T> {
     }
 }
 
+impl<T> Clone for WeakSender<T> {
+    /// Clones this [`WeakSender`].
+    fn clone(&self) -> Self {
+        Self { shared: self.shared.clone() }
+    }
+}
+
 /// The receiving end of a channel.
 ///
 /// Note: Cloning the receiver *does not* turn this channel into a broadcast channel.


### PR DESCRIPTION
Other `Weak` implementations (e.g. [sync::Weak](https://doc.rust-lang.org/stable/std/sync/struct.Weak.html) and [tokio::WeakSender](https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.WeakSender.html#impl-Clone-for-WeakSender%3CT%3E)) implement `Clone`, so I think this change is uncontroversial.

- Since `self.shared` is already `Clone` the change is trivial.