### PR TITLE
Add spinlock implementation without `std::thread::sleep`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,34 +13,45 @@ jobs:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        build: [linux64, macos, win32, win64]
+        build: [linux64, macos, win32, win64, wasm32]
         include:
           - build: linux64
             os: ubuntu-latest
             channel: stable
+            toolchain: x86_64-unknown-linux-gnu
             target: x86_64-unknown-linux-gnu
           #- build: linux32
           #  os: ubuntu-latest
           #  channel: stable
+          #  toolchain: i686-unknown-linux-gnu
           #  target: i686-unknown-linux-gnu
           - build: macos
             os: macos-latest
             channel: stable
+            toolchain: x86_64-apple-darwin
             target: x86_64-apple-darwin
           - build: win32
             os: windows-latest
             channel: stable
+            toolchain: i686-pc-windows-msvc
             target: i686-pc-windows-msvc
           - build: win64
             os: windows-latest
             channel: stable
+            toolchain: x86_64-pc-windows-msvc
             target: x86_64-pc-windows-msvc
+          - build: wasm32
+            os: ubuntu-latest
+            channel: stable
+            toolchain: x86_64-unknown-linux-gnu
+            target: wasm32-unknown-unknown
     steps:
     - uses: actions/checkout@v2
     - run: |
-        TOOLCHAIN=${{ matrix.channel }}-${{ matrix.target }}
+        TOOLCHAIN=${{ matrix.channel }}-${{ matrix.toolchain }}
         rustup toolchain install --no-self-update $TOOLCHAIN
         rustup default $TOOLCHAIN
+        rustup target add ${{ matrix.target }}
       shell: bash
     - name: Rust version
       run: |
@@ -53,6 +64,7 @@ jobs:
     - run: cargo check --target ${{ matrix.target }}
     - run: cargo build --target ${{ matrix.target }}
     - run: cargo test --target ${{ matrix.target }}
+      if: ${{ matrix.target != 'wasm32-unknown-unknown' }}
     # FIXME(#41): Some timeout/deadline tests make more sense to run in release mode.
     #- run: cargo test --release --target ${{ matrix.target }}
     - run: cargo build --all-targets --target ${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `spin-plain` feature that switches the locking implementation to a plain spinlock without `std::thread::sleep`
-
 ### Removed
 
 ### Changed
 
 - `WeakSender` is now `Clone`
+- `spin` feature no longer uses `std::thread::sleep` for locking except on Unix-like operating systems and Windows
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `spin-plain` feature that switches the locking implementation to a plain spinlock without `std::thread::sleep`
+
 ### Removed
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ exclude = [
 [features]
 # Use a spinlock internally (may be faster on some platforms)
 spin = []
-# Use a spinlock internally without `std::thread::sleep` (for platforms that don't support blocking)
-spin-plain = []
 select = []
 async = ["futures-sink", "futures-core"]
 eventual-fairness = ["select", "nanorand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ exclude = [
 [features]
 # Use a spinlock internally (may be faster on some platforms)
 spin = []
+# Use a spinlock internally without `std::thread::sleep` (for platforms that don't support blocking)
+spin-plain = []
 select = []
 async = ["futures-sink", "futures-core"]
 eventual-fairness = ["select", "nanorand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ async-std = { version = "1.9.0", features = ["attributes", "unstable"] }
 futures = { version = "^0.3", features = ["std"] }
 waker-fn = "1.1.0"
 tokio = { version = "^1.16.1", features = ["rt", "macros"] }
+getrandom = { version = "0.2.15", features = ["js"] }
 
 [[bench]]
 name = "basic"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[async_std::main]
 async fn main() {
     let (tx, rx) = flume::bounded(1);
@@ -17,5 +17,5 @@ async fn main() {
     t.await;
 }
 
-#[cfg(not(feature = "async"))]
+#[cfg(any(not(feature = "async"), target_os = "unknown"))]
 fn main() {}

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 use {
     flume::*,
     futures::{stream::FuturesUnordered, StreamExt, TryFutureExt, Future},
@@ -7,7 +7,7 @@ use {
     std::{time::Duration, sync::{atomic::{AtomicUsize, Ordering}, Arc}},
 };
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn r#async_recv() {
     let (tx, rx) = unbounded();
@@ -24,7 +24,7 @@ fn r#async_recv() {
     t.join().unwrap();
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn r#async_send() {
     let (tx, rx) = bounded(1);
@@ -41,7 +41,7 @@ fn r#async_send() {
     t.join().unwrap();
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn r#async_recv_disconnect() {
     let (tx, rx) = bounded::<i32>(0);
@@ -58,7 +58,7 @@ fn r#async_recv_disconnect() {
     t.join().unwrap();
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn r#async_send_disconnect() {
     let (tx, rx) = bounded(0);
@@ -75,7 +75,7 @@ fn r#async_send_disconnect() {
     t.join().unwrap();
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn r#async_recv_drop_recv() {
     let (tx, rx) = bounded::<i32>(10);
@@ -103,7 +103,7 @@ fn r#async_recv_drop_recv() {
     assert_eq!(t.join().unwrap(), Ok(42))
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[async_std::test]
 async fn r#async_send_1_million_no_drop_or_reorder() {
     #[derive(Debug)]
@@ -137,7 +137,7 @@ async fn r#async_send_1_million_no_drop_or_reorder() {
     assert_eq!(count, 1_000_000)
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[async_std::test]
 async fn parallel_async_receivers() {
     let (tx, rx) = flume::unbounded();
@@ -175,7 +175,7 @@ async fn parallel_async_receivers() {
     println!("recv end");
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn change_waker() {
     let (tx, rx) = flume::bounded(1);
@@ -246,7 +246,7 @@ fn change_waker() {
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn spsc_single_threaded_value_ordering() {
     async fn test() {

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 use {
     flume::*,
     futures::{stream::FuturesUnordered, StreamExt, TryFutureExt},
@@ -7,7 +7,7 @@ use {
 };
 use futures::{stream, Stream};
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn stream_recv() {
     let (tx, rx) = unbounded();
@@ -28,7 +28,7 @@ fn stream_recv() {
     t.join().unwrap();
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn stream_recv_disconnect() {
     let (tx, rx) = bounded::<i32>(0);
@@ -48,7 +48,7 @@ fn stream_recv_disconnect() {
     t.join().unwrap();
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn stream_recv_drop_recv() {
     let (tx, rx) = bounded::<i32>(10);
@@ -80,7 +80,7 @@ fn stream_recv_drop_recv() {
     assert_eq!(t.join().unwrap(), Some(42))
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn r#stream_drop_send_disconnect() {
     let (tx, rx) = bounded::<i32>(1);
@@ -98,7 +98,7 @@ fn r#stream_drop_send_disconnect() {
     t.join().unwrap();
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[async_std::test]
 async fn stream_send_1_million_no_drop_or_reorder() {
     #[derive(Debug)]
@@ -133,7 +133,7 @@ async fn stream_send_1_million_no_drop_or_reorder() {
     assert_eq!(count, 1_000_000)
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[async_std::test]
 async fn parallel_streams_and_async_recv() {
     let (tx, rx) = flume::unbounded();
@@ -174,7 +174,7 @@ async fn parallel_streams_and_async_recv() {
         .unwrap();
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[test]
 fn stream_no_double_wake() {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -220,7 +220,7 @@ fn stream_no_double_wake() {
     assert_eq!(count.load(Ordering::SeqCst), 1);
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", not(target_os = "unknown")))]
 #[async_std::test]
 async fn stream_forward_issue_55() { // https://github.com/zesterer/flume/issues/55
     fn dummy_stream() -> impl Stream<Item = usize> {


### PR DESCRIPTION
~This pull request adds a `spin-plain` feature that uses a spinlock-based locking system like the `spin` feature does, but without using `std::thread::sleep`. Closes #137.~
Edit: This pull request changes the `spin` feature to only use `std::thread::sleep` on Unix and Windows. Closes #137.

Some targets like `wasm32-unknown-unknown` don't support blocking, so you won't be able to use flume on those platforms without this new feature. Even if you enable `-Ctarget-feature=+atomics,+bulk-memory,+mutable-globals` on the `wasm32-unknown-unknown` target, flume still doesn't work on the main thread of a web browser, it only works in web workers. See #137 for more details about this, but essentially the problem is that the `wait_lock` function in flume has two different implementations and both of them are blocking, including the current spinlock-based one.