### PR TITLE
Add missing const _IS_BIASED in test/mpsc.rs

### DIFF
--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -175,6 +175,8 @@ macro_rules! select {
     (
         $($name:pat = $rx:ident.$meth:ident() => $code:expr),+
     ) => ({
+        const _IS_BIASED: bool = false;
+
         crossbeam_channel_internal! {
             $(
                 recv(($rx).inner) -> res => {


### PR DESCRIPTION
When I clone this repo to local and run `cargo test`, the compilation fails with "cannot find value `_IS_BIASED` in this scope" after the expansion of macro `select`. 
https://github.com/zesterer/flume/blob/fcf384956a7badd003c4eca43da5174f4e0c86a0/tests/mpsc.rs#L174-L187
What's more, I forked this repo and tried github workflows, which failed due to same reason.

I find it uses a macro export from `crossbeam-channel`. `flume` specifies `crossbeam-channel = "0.5.5"` in `[dev-dependencies]`. However, `crossbeam-channel` of version 0.5.5 has been yanked, so actually the newest version 0.5.13 is used. In the new version, a new value `_IS_BIASED` is used in macro `crossbeam_channel_internal`, resulting in the error above.

I find two use cases of `crossbeam_channel_internal` in [`crossbeam-channel` here](https://github.com/crossbeam-rs/crossbeam/blob/407375cb0dd55c60fcfb3e6764c745da3bef3739/crossbeam-channel/src/select_macro.rs#L1122-L1154):
```rust
macro_rules! select {
    ($($tokens:tt)*) => {
        {
            const _IS_BIASED: bool = false;


            $crate::crossbeam_channel_internal!(
                $($tokens)*
            )
        }
    };
}
#[macro_export]
macro_rules! select_biased {
    ($($tokens:tt)*) => {
        {
            const _IS_BIASED: bool = true;

            $crate::crossbeam_channel_internal!(
                $($tokens)*
            )
        }
    };
}
```

If this `select` macro is intended to work the same as `select` macro in `crossbeam_channel_internal`, adding the const `_IS_BIASED` with value `false` may help. After I added this value, the `cargo test` succeeded.