### PR TITLE
Threads waiting for data go to the front of the queue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,7 +595,7 @@ impl<T> Shared<T> {
             Err(TryRecvTimeoutError::Disconnected).into()
         } else if should_block {
             let hook = make_signal();
-            chan.waiting.push_back(hook.clone());
+            chan.waiting.push_front(hook.clone());
             drop(chan);
 
             do_block(hook)


### PR DESCRIPTION
Rather than using a round-robin approach for all threads waiting on the `recv`, prioritize the threads that were most recently active to pick up an item next.

Threads that have recently done some work have a higher chance of remaining in the cache. This approach is especially useful in scenarios where there are many more threads waiting to receive data than there are CPUs. Only when the system becomes backed up will threads further down the pipeline be awoken.

Imagine a scenario where we have 10 threads receiving on the channel, but usually there is only 1 item in the queue, so a single thread is able to process it all without more items accumulating. With this patch while the system is in this semi-idle state it will be always same thread, giving a slightly higher chance of its stack being still in cache.



This addresses #150 