### PR TITLE
doc: show required features on items on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ exclude = [
     "/misc",
 ]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 # Use a spinlock internally (may be faster on some platforms)
 spin = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! assert_eq!(rx.recv().unwrap(), 42);
 //! ```
 
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs)]
 
 #[cfg(feature = "select")]


### PR DESCRIPTION
Example output: <img width="1014" alt="example output with the changes from the MR, showing the `async` and `select` modules needing features of the same name to be available" src="https://github.com/user-attachments/assets/f7d19f5c-675c-428f-9ad2-0725c264772f">
