### PR TITLE
Fix warning about default_features being deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ default = ["async", "select", "eventual-fairness"]
 
 [dependencies]
 spin1 = { package = "spin", version = "0.9.8", features = ["mutex"] }
-futures-sink = { version = "0.3", default_features = false, optional = true }
-futures-core = { version = "0.3", default_features = false, optional = true }
+futures-sink = { version = "0.3", default-features = false, optional = true }
+futures-core = { version = "0.3", default-features = false, optional = true }
 nanorand = { version = "0.7", features = ["getrandom"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
When `cargo check` is run on master, the following warning is logged:

```
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `futures-core` dependency)
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `futures-sink` dependency)
```

This does not cause the process to exit with a non-zero exit code, which means this would not have been effecting CI.

This PR fixes that warning.
