### PR TITLE
Fix test warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
         rustup show
       shell: bash
     # Check build to fail fast
-    - run: cargo check --target ${{ matrix.target }}
+    - run: cargo check --tests --target ${{ matrix.target }}
     - run: cargo build --target ${{ matrix.target }}
     - run: cargo test --target ${{ matrix.target }}
       if: ${{ matrix.target != 'wasm32-unknown-unknown' }}

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -10,7 +10,7 @@ use std::thread;
 use std::time::Duration;
 
 use flume::{bounded, Receiver};
-use flume::{RecvError, RecvTimeoutError, TryRecvError};
+use flume::{RecvTimeoutError, TryRecvError};
 use flume::{SendError, SendTimeoutError, TrySendError};
 use crossbeam_utils::thread::scope;
 use rand::{thread_rng, Rng};

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -371,7 +371,7 @@ fn std_error_without_debug() {
     }
 
     match rx.recv() {
-        Ok(_) => {}
+        Ok(MessageWithoutDebug(n)) => assert_eq!(n, 1),
         Err(e) => {
             let _std_err: &dyn std::error::Error = &e;
         }
@@ -385,7 +385,7 @@ fn std_error_without_debug() {
     }
 
     match rx.try_recv() {
-        Ok(_) => {}
+        Ok(MessageWithoutDebug(n)) => assert_eq!(n, 2),
         Err(e) => {
             let _std_err: &dyn std::error::Error = &e;
         }
@@ -399,7 +399,7 @@ fn std_error_without_debug() {
     }
 
     match rx.recv_timeout(Duration::from_secs(10000000)) {
-        Ok(_) => {}
+        Ok(MessageWithoutDebug(n)) => assert_eq!(n, 3),
         Err(e) => {
             let _std_err: &dyn std::error::Error = &e;
         }

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -10,7 +10,7 @@ use std::thread;
 use std::time::Duration;
 
 use flume::{unbounded, Receiver};
-use flume::{RecvError, RecvTimeoutError, TryRecvError};
+use flume::{RecvTimeoutError, TryRecvError};
 use flume::{SendError, SendTimeoutError, TrySendError};
 use crossbeam_utils::thread::scope;
 use rand::{thread_rng, Rng};

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -1688,17 +1688,17 @@ mod select_tests {
         tx1.send(1).unwrap();
         select! {
             foo = rx1.recv() => { assert_eq!(foo.unwrap(), 1); },
-            _bar = rx2.recv() => { panic!() }
+            _bar = rx2.recv() => panic!()
         }
         tx2.send(2).unwrap();
         select! {
-            _foo = rx1.recv() => { panic!() },
-            bar = rx2.recv() => { assert_eq!(bar.unwrap(), 2) }
+            _foo = rx1.recv() => panic!(),
+            bar = rx2.recv() => assert_eq!(bar.unwrap(), 2)
         }
         drop(tx1);
         select! {
             foo = rx1.recv() => { assert!(foo.is_err()); },
-            _bar = rx2.recv() => { panic!() }
+            _bar = rx2.recv() => panic!()
         }
         drop(tx2);
         select! {
@@ -1715,10 +1715,10 @@ mod select_tests {
         let (tx5, rx5) = channel::<i32>();
         tx5.send(4).unwrap();
         select! {
-            _foo = rx1.recv() => { panic!("1") },
-            _foo = rx2.recv() => { panic!("2") },
-            _foo = rx3.recv() => { panic!("3") },
-            _foo = rx4.recv() => { panic!("4") },
+            _foo = rx1.recv() => panic!("1"),
+            _foo = rx2.recv() => panic!("2"),
+            _foo = rx3.recv() => panic!("3"),
+            _foo = rx4.recv() => panic!("4"),
             foo = rx5.recv() => { assert_eq!(foo.unwrap(), 4); }
         }
     }
@@ -1730,7 +1730,7 @@ mod select_tests {
         drop(tx2);
 
         select! {
-            _a1 = rx1.recv() => { panic!() },
+            _a1 = rx1.recv() => panic!(),
             a2 = rx2.recv() => { assert!(a2.is_err()); }
         }
     }
@@ -1754,12 +1754,12 @@ mod select_tests {
 
         select! {
             a = rx1.recv() => { assert_eq!(a.unwrap(), 1); },
-            _b = rx2.recv() => { panic!() }
+            _b = rx2.recv() => panic!()
         }
         tx3.send(1).unwrap();
         select! {
-            a = rx1.recv() => { assert!(a.is_err()) },
-            _b = rx2.recv() => { panic!() }
+            a = rx1.recv() => assert!(a.is_err()),
+            _b = rx2.recv() => panic!()
         }
         t.join().unwrap();
     }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -34,7 +34,7 @@ fn stream_recv_disconnect() {
     let (tx, rx) = bounded::<i32>(0);
 
     let t = std::thread::spawn(move || {
-        tx.send(42);
+        tx.send(42).unwrap();
         std::thread::sleep(std::time::Duration::from_millis(250));
         drop(tx)
     });
@@ -245,7 +245,10 @@ async fn stream_forward_issue_55() { // https://github.com/zesterer/flume/issues
 
         let recv_task = rx
             .into_stream()
-            .for_each(|item| async move {});
+            .enumerate()
+            .for_each(|(index, item)| async move {
+                assert_eq!(index, item);
+            });
         (send_task, recv_task)
     };
 

--- a/tests/zero.rs
+++ b/tests/zero.rs
@@ -10,7 +10,7 @@ use std::thread;
 use std::time::Duration;
 
 use flume::{bounded, Receiver};
-use flume::{RecvError, RecvTimeoutError, TryRecvError};
+use flume::{RecvTimeoutError, TryRecvError};
 use flume::{SendError, SendTimeoutError, TrySendError};
 use crossbeam_utils::thread::scope;
 use rand::{thread_rng, Rng};


### PR DESCRIPTION
On the master branch, there are 18 warnings which occur only in test modules. These warnings are not logged by `cargo check` alone, but they are logged if you run `cargo check --tests`. This PR:

- Fixes those warnings.
- Makes the CI run `cargo check --tests` to catch such things again in the future.

(Note: `cargo check --tests` _also_ logs warnings in the normal code too.)

(Note: I noticed this because I'm using the Zed editor which does this automatically in an integrated way.)