### PR TITLE
wasm: Avoid blocking the browser main thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ futures-sink = { version = "0.3", default-features = false, optional = true }
 futures-core = { version = "0.3", default-features = false, optional = true }
 fastrand = { version = "2.3", features = ["std", "js"], optional = true }
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasm_safe_mutex = { version = "0.2.0" }
+
 [dev-dependencies]
 #flume-test = { path = "../flume-test" }
 crossbeam-channel = "0.5.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ impl<T, S: ?Sized + Signal> Hook<T, S> {
     }
 
     fn lock(&self) -> Option<MutexGuard<'_, Option<T>>> {
-        self.0.as_ref().map(|s| s.lock().unwrap())
+        self.0.as_ref().map(|s| platform_lock(s).unwrap())
     }
 }
 
@@ -426,11 +426,24 @@ fn wait_lock<T>(lock: &Spinlock<T>) -> SpinlockGuard<'_, T> {
 #[cfg(not(feature = "spin"))]
 #[inline]
 fn wait_lock<'a, T>(lock: &'a Mutex<T>) -> MutexGuard<'a, T> {
-    lock.lock().unwrap()
+    platform_lock(lock).unwrap()
 }
 
-#[cfg(not(feature = "spin"))]
+#[cfg(all(not(feature = "spin"), not(target_family = "wasm")))]
 use std::sync::{Mutex, MutexGuard};
+#[cfg(all(not(feature = "spin"), target_family = "wasm"))]
+use wasm_safe_mutex::{Guard as MutexGuard, Mutex};
+
+#[cfg(not(target_family = "wasm"))]
+fn platform_lock<'a, T>(mutex: &'a Mutex<T>) -> std::sync::LockResult<MutexGuard<'a, T>> {
+    mutex.lock()
+}
+#[cfg(target_family = "wasm")]
+fn platform_lock<'a, T>(
+    mutex: &'a Mutex<T>,
+) -> Result<MutexGuard<'a, T>, std::convert::Infallible> {
+    Ok(mutex.lock_sync())
+}
 
 #[cfg(feature = "spin")]
 type ChanLock<T> = Spinlock<T>;


### PR DESCRIPTION
When using flume with Wasm in the browser, and without the spin feature, blocking when attempting to lock a mutex which is already locked on the main thread will panic and thereby crash the application.

To resolve the issue, use a spinlock on the browser main thread, through the `wasm_safe_mutex` crate. Web worker threads will continue to sleep when locking a mutex as usual.

----

Note: this isn't the most beautiful solution, as there are now 3 mutex implementations in the crate - unfortunately the ecosystem is in discord, with the standard library Mutex happily blocking the main thread on Wasm when this is a known problem, and browsers [refusing to allow blocking on the main thread](https://github.com/WebAssembly/threads/issues/106).

Theoretically we could only use `wasm_safe_mutex` for everything, as this provides the ability to spin or block and has async support, however (without any inspection whatsoever) I imagine that long-term the standard library's mutex is likely to be more efficient, especially as it would continuously receive updates and improvements over time from the entire community.

As such I have guarded this change behind flags so that `wasm_safe_mutex` is only used on Wasm platforms.

Fixes #173.