### PR TITLE
Add `Selector::send_or_else` to get the message back if not sent

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -111,24 +111,41 @@ impl<'a, T> Selector<'a, T> {
     ///
     /// Once added, the selector can be used to run the provided handler function on completion of this operation.
     pub fn send<U, F: FnOnce(Result<(), SendError<U>>) -> T + 'a>(
-        mut self,
+        self,
         sender: &'a Sender<U>,
         msg: U,
         mapper: F,
     ) -> Self {
-        struct SendSelection<'a, T, F, U> {
+        self.send_or_else(sender, msg, mapper, |_| {})
+    }
+
+    /// Add a send operation to the selector that sends the provided value.
+    ///
+    /// Once added, the selector can be used to run the provided handler function on completion of this operation.
+    ///
+    /// If another operation completes first, call the alternative handler instead.
+    pub fn send_or_else<U, F: FnOnce(Result<(), SendError<U>>) -> T + 'a, O: FnOnce(U) + 'a>(
+        mut self,
+        sender: &'a Sender<U>,
+        msg: U,
+        mapper: F,
+        or_else: O,
+    ) -> Self {
+        struct SendSelection<'a, T, F, O, U> {
             sender: &'a Sender<U>,
             msg: Option<U>,
             token: Token,
             signalled: Arc<Spinlock<VecDeque<Token>>>,
             hook: Option<Arc<Hook<U, SelectSignal>>>,
             mapper: Option<F>,
+            or_else: Option<O>,
             phantom: PhantomData<T>,
         }
 
-        impl<'a, T, F, U> Selection<'a, T> for SendSelection<'a, T, F, U>
+        impl<'a, T, F, O, U> Selection<'a, T> for SendSelection<'a, T, F, O, U>
         where
             F: FnOnce(Result<(), SendError<U>>) -> T,
+            O: FnOnce(U),
         {
             fn init(&mut self) -> Option<T> {
                 let token = self.token;
@@ -184,6 +201,10 @@ impl<'a, T> Selector<'a, T> {
             }
 
             fn deinit(&mut self) {
+                if let Some(msg) = self.msg.take() {
+                    (self.or_else.take().unwrap())(msg);
+                }
+
                 if let Some(hook) = self.hook.take() {
                     // Remove hook
                     let hook: Arc<Hook<U, dyn Signal>> = hook;
@@ -193,6 +214,10 @@ impl<'a, T> Selector<'a, T> {
                         .unwrap()
                         .1
                         .retain(|s| s.signal().as_ptr() != hook.signal().as_ptr());
+
+                    if let Some(msg) = hook.try_take() {
+                        (self.or_else.take().unwrap())(msg);
+                    }
                 }
             }
         }
@@ -205,6 +230,7 @@ impl<'a, T> Selector<'a, T> {
             signalled: self.signalled.clone(),
             hook: None,
             mapper: Some(mapper),
+            or_else: Some(or_else),
             phantom: Default::default(),
         }));
 

--- a/src/select.rs
+++ b/src/select.rs
@@ -110,7 +110,7 @@ impl<'a, T> Selector<'a, T> {
     /// Add a send operation to the selector that sends the provided value.
     ///
     /// Once added, the selector can be used to run the provided handler function on completion of this operation.
-    pub fn send<U, F: FnMut(Result<(), SendError<U>>) -> T + 'a>(
+    pub fn send<U, F: FnOnce(Result<(), SendError<U>>) -> T + 'a>(
         mut self,
         sender: &'a Sender<U>,
         msg: U,
@@ -122,13 +122,13 @@ impl<'a, T> Selector<'a, T> {
             token: Token,
             signalled: Arc<Spinlock<VecDeque<Token>>>,
             hook: Option<Arc<Hook<U, SelectSignal>>>,
-            mapper: F,
+            mapper: Option<F>,
             phantom: PhantomData<T>,
         }
 
         impl<'a, T, F, U> Selection<'a, T> for SendSelection<'a, T, F, U>
         where
-            F: FnMut(Result<(), SendError<U>>) -> T,
+            F: FnOnce(Result<(), SendError<U>>) -> T,
         {
             fn init(&mut self) -> Option<T> {
                 let token = self.token;
@@ -155,7 +155,7 @@ impl<'a, T> Selector<'a, T> {
                 );
 
                 if self.hook.is_none() {
-                    Some((self.mapper)(match r {
+                    Some((self.mapper.take().unwrap())(match r {
                         Ok(()) => Ok(()),
                         Err(TrySendTimeoutError::Disconnected(msg)) => Err(SendError(msg)),
                         _ => unreachable!(),
@@ -180,7 +180,7 @@ impl<'a, T> Selector<'a, T> {
                     return None;
                 };
 
-                Some((self.mapper)(res))
+                Some((self.mapper.take().unwrap())(res))
             }
 
             fn deinit(&mut self) {
@@ -204,7 +204,7 @@ impl<'a, T> Selector<'a, T> {
             token,
             signalled: self.signalled.clone(),
             hook: None,
-            mapper,
+            mapper: Some(mapper),
             phantom: Default::default(),
         }));
 
@@ -214,7 +214,7 @@ impl<'a, T> Selector<'a, T> {
     /// Add a receive operation to the selector.
     ///
     /// Once added, the selector can be used to run the provided handler function on completion of this operation.
-    pub fn recv<U, F: FnMut(Result<U, RecvError>) -> T + 'a>(
+    pub fn recv<U, F: FnOnce(Result<U, RecvError>) -> T + 'a>(
         mut self,
         receiver: &'a Receiver<U>,
         mapper: F,
@@ -224,14 +224,14 @@ impl<'a, T> Selector<'a, T> {
             token: Token,
             signalled: Arc<Spinlock<VecDeque<Token>>>,
             hook: Option<Arc<Hook<U, SelectSignal>>>,
-            mapper: F,
+            mapper: Option<F>,
             received: bool,
             phantom: PhantomData<T>,
         }
 
         impl<'a, T, F, U> Selection<'a, T> for RecvSelection<'a, T, F, U>
         where
-            F: FnMut(Result<U, RecvError>) -> T,
+            F: FnOnce(Result<U, RecvError>) -> T,
         {
             fn init(&mut self) -> Option<T> {
                 let token = self.token;
@@ -254,7 +254,7 @@ impl<'a, T> Selector<'a, T> {
                 );
 
                 if self.hook.is_none() {
-                    Some((self.mapper)(match r {
+                    Some((self.mapper.take().unwrap())(match r {
                         Ok(msg) => Ok(msg),
                         Err(TryRecvTimeoutError::Disconnected) => Err(RecvError::Disconnected),
                         _ => unreachable!(),
@@ -274,7 +274,7 @@ impl<'a, T> Selector<'a, T> {
                     return None;
                 };
 
-                Some((self.mapper)(res))
+                Some((self.mapper.take().unwrap())(res))
             }
 
             fn deinit(&mut self) {
@@ -306,7 +306,7 @@ impl<'a, T> Selector<'a, T> {
             token,
             signalled: self.signalled.clone(),
             hook: None,
-            mapper,
+            mapper: Some(mapper),
             received: false,
             phantom: Default::default(),
         }));

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -333,7 +333,7 @@ fn select_general() {
     let (tx0, rx0) = bounded(1);
     let (tx1, rx1) = unbounded();
 
-    for (i, t) in vec![tx0.clone(), tx1].into_iter().enumerate() {
+    for (i, t) in vec![tx0.clone(), tx1.clone()].into_iter().enumerate() {
         std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(250));
             let _ = t.send(Foo(i));
@@ -374,6 +374,37 @@ fn select_general() {
         .unwrap();
 
     t.join().unwrap();
+
+    let mut else0 = None;
+    let mut else1 = None;
+    let res = Selector::new()
+        .send_or_else(
+            &tx0,
+            Foo(44),
+            |x| {
+                x.unwrap_err();
+                0
+            },
+            |x| else0 = Some(x),
+        )
+        .send_or_else(
+            &tx1,
+            Foo(45),
+            |x| {
+                x.unwrap();
+                1
+            },
+            |x| else1 = Some(x),
+        )
+        .wait();
+
+    if res == 0 {
+        assert_eq!(else0, None);
+        assert_eq!(else1, Some(Foo(45)));
+    } else {
+        assert_eq!(else0, Some(Foo(44)));
+        assert_eq!(else1, None);
+    }
 }
 
 struct MessageWithoutDebug(u32);

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -340,8 +340,12 @@ fn select_general() {
         });
     }
 
+    let token = Box::new(());
     let x = Selector::new()
-        .recv(&rx0, |x| x)
+        .recv(&rx0, |x| {
+            drop(token);
+            x
+        })
         .recv(&rx1, |x| x)
         .wait()
         .unwrap();
@@ -360,7 +364,14 @@ fn select_general() {
         assert_eq!(rx0.recv().unwrap(), Foo(43));
     });
 
-    Selector::new().send(&tx0, Foo(43), |x| x).wait().unwrap();
+    let token = Box::new(());
+    Selector::new()
+        .send(&tx0, Foo(43), |x| {
+            drop(token);
+            x
+        })
+        .wait()
+        .unwrap();
 
     t.join().unwrap();
 }


### PR DESCRIPTION
All the send methods in `flume` return an error type that gives you your original message back if it was not sent, except for `SelectError`. This makes sense because `SelectError::Timeout` might be caused by multiple send operations all timing out, or none if the `Selector` only has receives.

I wanted to wrap my existing `flume-based` API with a hidden interruptor channel, to allow blocking waits to be terminated early. So I was transforming what was previously calls to `Sender::send_*` into `Selector::new().send(...).recv(&INTERRUPT_CHANNEL).wait_*`, but this meant I could no longer get my original message back in the case of timeouts or interruptions.

My first attempt to fix this involved wrapping the message in an `Arc<Mutex<Option<T>>>` to allow me to claw it back if it wasn't claimed by the receiving end of the channel, which ran into an annoyance where I had to `clone()` the Arc in the `Selector::send()` closure because it was `FnMut` instead of `FnOnce`. The first commit in this PR fixes this issue. Since all `FnMut` closures are subtypes of `FnOnce` this is a non-breaking change to `flume`'s API.

I didn't like the extra cost of the `Arc<Mutex<...>>` so I hypothesised a way to get my message back via a different closure if the `send` branch wasn't taken. That is the second commit in this PR (also a non-breaking change, adding a new method to `Selector`).

This allowed me to write:

```rust
    fn send_blocking(
        &mut self,
        msg: S,
        timeout: Option<Duration>,
    ) -> Result<(), SendTimeoutError<S, E>> {
        enum SendResult {
            Sent,
            Interrupted,
        }

        let mut unsent_msg = None;

        let selector = flume::Selector::new()
            .send_or_else(
                &self.channel.sender,
                msg,
                |res| {
                    res.and(Ok(SendResult::Sent))
                        .or_else(|flume::SendError(msg)| Err(SendTimeoutError::Closed(msg)))
                },
                |msg| unsent_msg = Some(msg),
            )
            .recv(&INTERRUPT_CHANNEL, |res| {
                res.and(Ok(SendResult::Interrupted)).or_else(|e| match e {
                    flume::RecvError::Disconnected => {
                        panic!("static channel should not get disconnected")
                    }
                })
            });

        let res = match selector.wait_timeout(timeout.unwrap_or(Duration::MAX)) {
            Ok(res) => res?,
            Err(flume::select::SelectError::Timeout) => {
                return Err(SendTimeoutError::Timeout(unsent_msg.take().unwrap()));
            }
        };

        match res {
            SendResult::Sent => Ok(()),
            SendResult::Interrupted => {
                Err(SendTimeoutError::Interrupted(unsent_msg.take().unwrap()))
            }
        }
    }
```