### PR TITLE
Update spin dependency to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ eventual-fairness = ["select", "fastrand"]
 default = ["async", "select", "eventual-fairness"]
 
 [dependencies]
-spin1 = { package = "spin", version = "0.9.8", features = ["mutex"] }
+spin1 = { package = "spin", version = "0.10", features = ["mutex"] }
 futures-sink = { version = "0.3", default-features = false, optional = true }
 futures-core = { version = "0.3", default-features = false, optional = true }
 fastrand = { version = "2.3", features = ["std", "js"], optional = true }


### PR DESCRIPTION
Updates the spin dependency from the yanked 0.9.8 release to 0.10. The Mutex and MutexGuard APIs used by flume remain compatible. Verified with cargo test --all-features on the 0.12 tag: all unit, integration, stress, and documentation tests passed.