### PR TITLE
Update spin to 0.10 on the 0.11 line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ eventual-fairness = ["select", "nanorand"]
 default = ["async", "select", "eventual-fairness"]
 
 [dependencies]
-spin1 = { package = "spin", version = "0.9.8", features = ["mutex"] }
+spin1 = { package = "spin", version = "0.10", features = ["mutex"] }
 futures-sink = { version = "0.3", default_features = false, optional = true }
 futures-core = { version = "0.3", default_features = false, optional = true }
 nanorand = { version = "0.7", features = ["getrandom"], optional = true }


### PR DESCRIPTION
The spin 0.9.8 release is yanked, which causes strict Cargo audits to fail for downstream users of flume 0.11.1.

This updates the dependency requirement to spin 0.10 while retaining the existing mutex feature. The full flume 0.11 test suite passes with all features enabled, including stress tests and doc tests.

This is intentionally based on the flume 0.11.1 release commit so projects whose dependency constraints do not accept flume 0.12 have an upgrade path.